### PR TITLE
Fixed Visiblility of Join as Student Button

### DIFF
--- a/src/components/home/CTASection.tsx
+++ b/src/components/home/CTASection.tsx
@@ -65,7 +65,7 @@ export const CTASection: React.FC = () => {
             >
               <Button 
                 size="lg" 
-                className="bg-white text-indigo-600 hover:bg-gray-50 shadow-xl hover:shadow-2xl transform transition-all duration-300 group px-8 py-4 rounded-2xl font-semibold border-2 border-white"
+                className="border-2 border-white text-white hover:bg-white hover:text-indigo-600 backdrop-blur-sm px-8 py-4 rounded-2xl font-semibold bg-white/10 shadow-lg hover:shadow-xl transition-all duration-300"
                 onClick={() => {
                   const element = document.getElementById('auth-section');
                   element?.scrollIntoView({ behavior: 'smooth' });


### PR DESCRIPTION
The ‘Join as Student (Free)’ button above the footer had a visibility issue because the text color and background color were the same, making the text unreadable.

Fixes Done:
I fixed this by updating the button style similar to Become a mentor button so that the text is clearly visible against the background.
<img width="1718" height="827" alt="image" src="https://github.com/user-attachments/assets/d1eed7c0-5bc0-45c1-a98b-ffe5a7d69dc7" />
